### PR TITLE
Update README.md for improved shell script syntax highlighting

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -233,6 +233,8 @@ bool getBit(int num, int i) {
  * scheme ('*.scm')
 
  * scss ('*.scss')
+ 
+ * shell ('*.sh', '*.bash', '*.bats', '*.cgi', '*.command', '*.fcgi', '*.ksh', '*.sh.in', '*.tmux', '*.tool', '*.trigger', '*.zsh', '*.zsh-theme')
 
  * smalltalk ('*.st')
 


### PR DESCRIPTION
Update the `README.md` to include proper syntax highlighting for various **shell script file extensions** such as `.sh`, `.bash`, `.ksh`, and `.zsh`. These extensions are supported by GitHub’s syntax highlighter as defined in the GitHub Linguist documentation, ensuring better readability for shell scripts in Markdown files."

For more information, refer to the [GitHub Linguist documentation](https://github.com/github-linguist/linguist/blob/be39d09a3789d068afb33533f285df02d8e9c367/lib/linguist/languages.yml#L6810)